### PR TITLE
stems, affixes and roots load from route

### DIFF
--- a/src/actions/shared.js
+++ b/src/actions/shared.js
@@ -10,13 +10,14 @@ export function handleInitialAppData (client) {
   return (dispatch) => {
     dispatch(showLoading())
     return getInitialAppData(client)
-      .then(({ stems, affixes }) => {
+      .then(({ stems, roots, affixes }) => {
         dispatch(receiveStems(stems))
-        //dispatch(handleStemPageChange(0))
-       //dispatch(handleStemPageSizeChange(10, 0))
-       //dispatch(handleAffixPageChange(0))
-       //dispatch(handleAffixPageSizeChange(10, 0))
+        dispatch(receiveRoots(roots))
         dispatch(receiveAffixes(affixes))
+        //dispatch(handleStemPageChange(0))
+        //dispatch(handleStemPageSizeChange(10, 0))
+        //dispatch(handleAffixPageChange(0))
+        //dispatch(handleAffixPageSizeChange(10, 0))
         //dispatch(receiveNavBar(navbar))
         //dispatch(receiveUsers(users))
         dispatch(hideLoading())

--- a/src/components/AffixList.js
+++ b/src/components/AffixList.js
@@ -9,6 +9,7 @@ import { handleDeleteAffix, handleAffixPageChange,
   handleAffixPageSizeChange, handleAffixSortedChange,
   handleAffixFilteredChange, handleAffixResizedChange } from '../actions/affixes'
 import { hashToArray } from '../utils/helpers'
+import { loadState }  from '../utils/localStorage'
 
 class AffixList extends Component {
 
@@ -21,6 +22,8 @@ class AffixList extends Component {
     this.onSortedChange = this.onSortedChange.bind(this)
     this.onFilteredChange = this.onFilteredChange.bind(this)
     this.onResizedChange = this.onResizedChange.bind(this)
+    const serializedState = loadState()
+    this.state = {affixes: serializedState.affixes}
   }
 
   async onDelete(id) {
@@ -52,7 +55,7 @@ class AffixList extends Component {
   }
 
   render() {
-    const { affixes } = this.props
+    const { affixes } = this.state
     const columns = [
       {
         Header: 'ID',
@@ -134,7 +137,8 @@ class AffixList extends Component {
 }
 
 function mapStateToProps (state) {
-  const {affixes} = state
+  const serializedState = loadState()
+  const {affixes} = serializedState
   return {
     affixes
   }

--- a/src/components/RootList.js
+++ b/src/components/RootList.js
@@ -9,6 +9,7 @@ import { handleDeleteRoot, handleRootPageChange,
   handleRootPageSizeChange, handleRootSortedChange,
   handleRootFilteredChange, handleRootResizedChange } from '../actions/roots'
 import { hashToArray } from '../utils/helpers'
+import { loadState }  from '../utils/localStorage'
 
 class RootList extends Component {
 
@@ -21,6 +22,8 @@ class RootList extends Component {
     this.onSortedChange = this.onSortedChange.bind(this)
     this.onFilteredChange = this.onFilteredChange.bind(this)
     this.onResizedChange = this.onResizedChange.bind(this)
+    const serializedState = loadState()
+    this.state = {roots: serializedState.roots}
   }
 
   async onDelete(id) {
@@ -52,7 +55,7 @@ class RootList extends Component {
   }
 
   render() {
-    const { roots } = this.props
+    const { roots } = this.state
     console.log('Roots=', roots)
     const columns = [
       {
@@ -168,7 +171,7 @@ class RootList extends Component {
   const table =
     <ReactTable
       data={roots.data}
-      // page={roots.tableData.page}
+      page={roots.tableData.page}
       pageSize={roots.tableData.pageSize}
       filtered={roots.tableData.filtered}
       sorted={roots.tableData.sorted}
@@ -191,7 +194,8 @@ class RootList extends Component {
 }
 
 function mapStateToProps (state) {
-  const {roots} = state
+  const serializedState = loadState()
+  const {roots} = serializedState
   return {
     roots
   }

--- a/src/components/StemList.js
+++ b/src/components/StemList.js
@@ -11,7 +11,6 @@ import { handleDeleteStem, handleStemPageChange,
 import { hashToArray } from '../utils/helpers'
 import { loadState }  from '../utils/localStorage'
 
-
 class StemList extends Component {
 
   constructor(props) {
@@ -24,12 +23,8 @@ class StemList extends Component {
     this.onFilteredChange = this.onFilteredChange.bind(this)
     this.onResizedChange = this.onResizedChange.bind(this)
     const serializedState = loadState()
-    console.log('here is my goddamned stems.tabledata state from constructor ', serializedState.stems.tabledata)
+    console.log('here is my goddamned stems.tableData state from constructor ', serializedState.stems.tableData)
     this.state = {stems: serializedState.stems}
-  }
-
-  componentDidMount() {
-
   }
 
   async onDelete(id) {
@@ -44,7 +39,7 @@ class StemList extends Component {
   async onPageChange(page) {
     await this.props.dispatch(handleStemPageChange(page))
     let currentState = this.state
-    currentState.stems.tabledata.page = page
+    currentState.stems.tableData.page = page
     this.setState(currentState)
   }
 
@@ -154,30 +149,33 @@ class StemList extends Component {
         )
       }
     ]
-
-    return (
+    const table =
       <ReactTable
-        data={stems.data}
-        columns={columns}
-        page={stems.tabledata.page}
-        //pageSize={stems.tableData.pageSize}
-        //filtered={stems.tableData.filtered}
-        //sorted={stems.tableData.sorted}
-        //resized={stems.tableData.resized}
-        filterable
-        onPageChange={page => this.onPageChange(page)}
-        onPageSizeChange={(pageSize,page) => this.onPageSizeChange(pageSize,page)}
-        onSortedChange={(newSorted,column,shiftKey) => this.onSortedChange(newSorted,column,shiftKey)}
-        onResizedChange={(newResized, event) => this.onResizedChange(newResized, event)}
-        onFilteredChange={(filtered, column) => this.onFilteredChange(filtered,column)}
-      />
+      data={stems.data}
+      columns={columns}
+      page={stems.tableData.page}
+      pageSize={stems.tableData.pageSize}
+      filtered={stems.tableData.filtered}
+      sorted={stems.tableData.sorted}
+      resized={stems.tableData.resized}
+      filterable
+      onPageChange={page => this.onPageChange(page)}
+      onPageSizeChange={(pageSize,page) => this.onPageSizeChange(pageSize,page)}
+      onSortedChange={(newSorted,column,shiftKey) => this.onSortedChange(newSorted,column,shiftKey)}
+      onResizedChange={(newResized, event) => this.onResizedChange(newResized, event)}
+      onFilteredChange={(filtered, column) => this.onFilteredChange(filtered,column)}
+    />
+    return (
+      <React.Fragment>
+        {table}
+      </React.Fragment>
     )
   }
 }
 
 function mapStateToProps (state) {
   const serializedState = loadState()
-  console.log('here is my goddam stems.tabledata state ', serializedState.stems.tabledata)
+  console.log('here is my goddam stems.tableData state ', serializedState.stems.tableData)
   const {stems} = serializedState
   return {
     stems

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,12 +1,14 @@
 import { combineReducers } from 'redux'
 import users from './users'
 import affixes from './affixes'
+import roots from './roots'
 import stems from './stems'
 //import navbar from './navbar'
 import { loadingBarReducer } from 'react-redux-loading'
 
 export default combineReducers({
   stems,
+  roots,
   affixes,
   //navbar,
   users,

--- a/src/reducers/stems.js
+++ b/src/reducers/stems.js
@@ -44,8 +44,8 @@ export default function stems (state = {}, action) {
     case SET_STEM_PAGE_SIZE :
       return {
         ...state,
-        tabledata: {
-          ...state.tabledata,
+        tableData: {
+          ...state.tableData,
           pageSize: action.pageSize,
           page: action.page
         }
@@ -53,32 +53,32 @@ export default function stems (state = {}, action) {
     case SET_STEM_PAGE :
       return {
         ...state,
-        tabledata: {
-          ...state.tabledata,
+        tableData: {
+          ...state.tableData,
           page: action.page
         }
       }
     case SET_STEM_SORTED :
       return {
         ...state,
-        tabledata: {
-          ...state.tabledata,
+        tableData: {
+          ...state.tableData,
           sorted: action.newSorted
         }
       }
     case SET_STEM_FILTERED :
       return {
         ...state,
-        tabledata: {
-          ...state.tabledata,
+        tableData: {
+          ...state.tableData,
           filtered: action.filtered
         }
       }
     case SET_STEM_RESIZED :
       return {
         ...state,
-        tabledata: {
-          ...state.tabledata,
+        tableData: {
+          ...state.tableData,
           resized: action.resized
         }
       }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -22,7 +22,7 @@ export function getInitialAppData (client) {
   ]).then(([stems, roots, affixes]) => ({
     stems: {
       data: stems.data.stems_Q,
-      tabledata: {
+      tableData: {
         page: 0,
         pageSize: 10,
         sorted: [{


### PR DESCRIPTION
the application can now load directly from a component (i.e. at /roots you can reload, and it won't break).  No state storms, it seems!

careful, though - the load/reload has to complete (loadingbar has to disappear) before you try to navigate to another route, or you'll get the familiar '*.tableData is not defined'. 

I think we need to either disable navigation during loading, or add something that allows the app to handle this better.