### PR TITLE
fixed table actions to load subcomponents

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -81,9 +81,9 @@ class App extends Component {
   }
 }
 
-function mapStateToProps ({ stems, roots, affixes, errors }) {
+function mapStateToProps ({ stems, roots, affixes, texts, errors }) {
   return {
-    loading: stems === null || roots === null || affixes === null,
+    loading: stems === null || roots === null || affixes === null || texts === null,
     errors: errors
   }
 }

--- a/src/components/TextList.js
+++ b/src/components/TextList.js
@@ -26,17 +26,17 @@ class TextsList extends Component {
   }
 
   //we call our main function, which includes all the helper functions.
-  async componentDidMount() {
-    const getTextData = await this.props.client.query({
-      query: getTextsQuery,
-      variables: {
-      }
-    })
-    let data = getTextData.data.texts_Q
-    console.log('here is my data in ComponentDidMount ', data)
-    let newData = this.sourcefiles(data)
-    console.log('here is my newData ', newData)
-  }
+  // async componentDidMount() {
+  //   const getTextData = await this.props.client.query({
+  //     query: getTextsQuery,
+  //     variables: {
+  //     }
+  //   })
+  //   let tData = getTextData.data.texts_Q
+  //   console.log('here is my data in ComponentDidMount ', tData)
+  //   let newData = this.sourcefiles(tData)
+  //   console.log('here is my newData ', newData)
+  // }
 
   async onPageChange(page) {
     await this.props.dispatch(handleTextPageChange(page))
@@ -75,101 +75,6 @@ class TextsList extends Component {
     this.setState(currentState)
   }
 
-sourcefiles(json) {
-  //you have the data from getTextsQuery, call it json.
-  //Now reformulate it so that the ReactTable display can handle it.
-    let i = 0;
-    let k = 0;
-    //set an empty string to hold handImages, and one to hold typedImages.
-    //These are needed for the SplitView utility that displays handwritten and
-    //typed fieldnotes side-by-side.
-    while (i < json.length) {
-      let handImages = '';
-      let typedImages = '';
-      //set an empty array to hold 'sourcefiles'.
-      json[i]["sourcefiles"] = [];
-      let j=0;
-      //for each text, provide the data fields 'src', 'title', 'fileType'
-      //'msType'.  Set the entry type as 'text', and give it a key.
-      while (j < json[i]["textfiles"].length) {
-        json[i]["sourcefiles"].push(
-          {
-            src: json[i]["textfiles"][j].src,
-            title: json[i]["textfiles"][j].resType + " pdf",
-            fileType: json[i]["textfiles"][j].fileType,
-            msType: json[i]["textfiles"][j].msType,
-            type: "text",
-            key: k
-          }
-        );
-        if (json[i]["textfiles"][j]["textimages"].length > 0) {
-          k++;
-          // for each textfile, build the query string so that imageviewer can derive the images from it.
-          let l = 0;
-          json[i]["textfiles"][j]["imagequerystring"]='';
-          while (l < json[i]["textfiles"][j]["textimages"].length) {
-            json[i]["textfiles"][j]["imagequerystring"] = json[i]["textfiles"][j]["imagequerystring"] + '&images=' + json[i]["textfiles"][j]["textimages"][l]["src"];
-            l++;
-          }
-          console.log(json[i]["textfiles"][j]["imagequerystring"]);
-        json[i]["sourcefiles"].push(
-            {
-              src: json[i]["textfiles"][j]["imagequerystring"],
-              title: json[i]["textfiles"][j].resType + " image files",
-              fileType: json[i]["textfiles"][j].fileType,
-              type: "textimages",
-              key: k
-            }
-          );
-          //SplitView needs to know if the imagefiles are for handwritten
-          //or typed fieldnotes.  Here's where we tell it.
-          if (json[i]["textfiles"][j].msType === "Handwritten") {
-            handImages = json[i]["textfiles"][j]["imagequerystring"];
-          }
-            if (json[i]["textfiles"][j].msType === "Typed") {
-            typedImages = json[i]["textfiles"][j]["imagequerystring"];
-          }
-        }
-        j++; k++;
-      }
-      j=0;
-      while (j < json[i]["audiosets"].length) {
-        //here we create the data that is needed to pass to the AudioPlayer
-        json[i]["sourcefiles"].push(
-          {
-            speaker: json[i]["audiosets"][j].speaker,
-            title: json[i]["audiosets"][j].title,
-            sources: json[i]["audiosets"][j].audiofiles,
-            type: "audio",
-            key: k
-          }
-        );
-        j++; k++;
-      }
-      //SplitView should only appear if a text has both a set of handwritten
-      //fieldnots and a corresponding set of typed manuscripts.
-      //For SplitView to read in the imagefiles into the, correct gallery
-      //we need to modify the query string to replace every instance of
-      //'images' with either 'handimages' or 'typedimages'.  We use unshift
-      //instead of push to put the SplitView at the top of the versions list,
-      //iff a text has a SplitView.
-      if ( handImages.length >0 && typedImages.length >0){
-        handImages=handImages.replace(/images/g, "handimages");
-      typedImages=typedImages.replace(/images/g, "typedimages");
-      json[i]["sourcefiles"].unshift(
-        {
-          src: handImages + typedImages,
-          title: "Dual view of typed and handwritten notes",
-          fileType: "images",
-          type: "splitview",
-          key: k
-        }
-      );
-      }
-      i++;
-    }
-    return json;
- }
   //weblink builds the clickable link for a textfile.
   weblink(link, page) {
     return (
@@ -300,7 +205,7 @@ sourcefiles(json) {
 
 function mapStateToProps (state) {
   const serializedState = loadState()
-  console.log('here is my texts.tableData state ', serializedState.texts.tableData)
+  console.log('here is my texts state ', serializedState.texts)
   const {texts} = serializedState
   return {
     texts

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,7 @@ const store = createStore(
 )
 
 store.subscribe(() => {
+  console.log('I am saving the state into localStorage')
   saveState(store.getState())
 })
 

--- a/src/reducers/texts.js
+++ b/src/reducers/texts.js
@@ -1,12 +1,112 @@
 import { RECEIVE_TEXTS, SET_TEXT_PAGE_SIZE, SET_TEXT_PAGE,
   SET_TEXT_FILTERED, SET_TEXT_SORTED, SET_TEXT_RESIZED} from '../actions/texts'
 
+function sourcefiles(jsonData) {
+  let json = JSON.parse(JSON.stringify(jsonData))
+  //you have the data from getTextsQuery, call it json.
+  //Now reformulate it so that the ReactTable display can handle it.
+    let i = 0;
+    let k = 0;
+    //set an empty string to hold handImages, and one to hold typedImages.
+    //These are needed for the SplitView utility that displays handwritten and
+    //typed fieldnotes side-by-side.
+    while (i < json.length) {
+      let handImages = '';
+      let typedImages = '';
+      //set an empty array to hold 'sourcefiles'.
+      json[i]["sourcefiles"] = [];
+      let j=0;
+      //for each text, provide the data fields 'src', 'title', 'fileType'
+      //'msType'.  Set the entry type as 'text', and give it a key.
+      while (j < json[i]["textfiles"].length) {
+        json[i]["sourcefiles"].push(
+          {
+            src: json[i]["textfiles"][j].src,
+            title: json[i]["textfiles"][j].resType + " pdf",
+            fileType: json[i]["textfiles"][j].fileType,
+            msType: json[i]["textfiles"][j].msType,
+            type: "text",
+            key: k
+          }
+        );
+        if (json[i]["textfiles"][j]["textimages"].length > 0) {
+          k++;
+          // for each textfile, build the query string so that imageviewer can derive the images from it.
+          let l = 0;
+          json[i]["textfiles"][j]["imagequerystring"]='';
+          while (l < json[i]["textfiles"][j]["textimages"].length) {
+            json[i]["textfiles"][j]["imagequerystring"] = json[i]["textfiles"][j]["imagequerystring"] + '&images=' + json[i]["textfiles"][j]["textimages"][l]["src"];
+            l++;
+          }
+          console.log(json[i]["textfiles"][j]["imagequerystring"]);
+        json[i]["sourcefiles"].push(
+            {
+              src: json[i]["textfiles"][j]["imagequerystring"],
+              title: json[i]["textfiles"][j].resType + " image files",
+              fileType: json[i]["textfiles"][j].fileType,
+              type: "textimages",
+              key: k
+            }
+          );
+          //SplitView needs to know if the imagefiles are for handwritten
+          //or typed fieldnotes.  Here's where we tell it.
+          if (json[i]["textfiles"][j].msType === "Handwritten") {
+            handImages = json[i]["textfiles"][j]["imagequerystring"];
+          }
+            if (json[i]["textfiles"][j].msType === "Typed") {
+            typedImages = json[i]["textfiles"][j]["imagequerystring"];
+          }
+        }
+        j++; k++;
+      }
+      j=0;
+      while (j < json[i]["audiosets"].length) {
+        //here we create the data that is needed to pass to the AudioPlayer
+        json[i]["sourcefiles"].push(
+          {
+            speaker: json[i]["audiosets"][j].speaker,
+            title: json[i]["audiosets"][j].title,
+            sources: json[i]["audiosets"][j].audiofiles,
+            type: "audio",
+            key: k
+          }
+        );
+        j++; k++;
+      }
+      //SplitView should only appear if a text has both a set of handwritten
+      //fieldnots and a corresponding set of typed manuscripts.
+      //For SplitView to read in the imagefiles into the, correct gallery
+      //we need to modify the query string to replace every instance of
+      //'images' with either 'handimages' or 'typedimages'.  We use unshift
+      //instead of push to put the SplitView at the top of the versions list,
+      //iff a text has a SplitView.
+      if ( handImages.length >0 && typedImages.length >0){
+        handImages=handImages.replace(/images/g, "handimages");
+      typedImages=typedImages.replace(/images/g, "typedimages");
+      json[i]["sourcefiles"].unshift(
+        {
+          src: handImages + typedImages,
+          title: "Dual view of typed and handwritten notes",
+          fileType: "images",
+          type: "splitview",
+          key: k
+        }
+      );
+      }
+      i++;
+    }
+    return json;
+ }
+
 export default function texts (state = {}, action) {
   switch (action.type) {
     case RECEIVE_TEXTS :
+      console.log('here is sourcefiles(action.texts)', action.texts)
+      console.log('here is sourcefiles(action.texts.data)', sourcefiles(action.texts.data))
       return {
         ...state,
         ...action.texts,
+        data: sourcefiles(action.texts.data),
       }
     case SET_TEXT_PAGE_SIZE :
       return {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -237,3 +237,4 @@ export function editStem(client, stem){
     }
   })
 }
+


### PR DESCRIPTION
The texts component now gets the data it needs in order to display the table rows and their subcomponents; sourcefile data comes in via the receive_texts action.  We have not yet loaded the image file view features, but if you run the static server in addition to the backend and frontend components, you can click through to access pdfs.  